### PR TITLE
Add configuration for compatibility with mkdocs 1.2.3

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-recursive-include mkDOCter *.ico *.js *.css *.png *.html *.eot *.svg *.ttf *.woff
+recursive-include mkDOCter *.ico *.js *.css *.png *.html *.eot *.svg *.ttf *.woff *.yml
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 include TERMS.md

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,6 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
     ]
 )


### PR DESCRIPTION
To update compatibility, this PR makes two changes:
- Adds a `mkdocs_theme.yml` file, required as of [mkdocs v 0.17.0](https://www.mkdocs.org/about/release-notes/#version-0170-2017-10-19) – even if it's empty. 
- Adds Python 3.8 to the classifiers in setup.py, to conform with cfpb usage.